### PR TITLE
Upgrade to 5.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.0
+
+* Upgrade Curator to v5.5.4.
+
 ## 4.2.6
 
 * Package Curator v4.2.6.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @itskingori @tsu-shiuan @zacblazic

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Zappi DevOps <devops@zappistore.com>"
 
 ARG APP_DEPS="python py-setuptools"
 ARG BUILD_DEPS="py-pip"
-ARG CURATOR_VERSION="4.2.6"
+ARG CURATOR_VERSION="5.5.4"
 
 RUN apk --update add ${APP_DEPS} ${BUILD_DEPS} && \
     pip install elasticsearch-curator==${CURATOR_VERSION} && \


### PR DESCRIPTION
Upgrades curator to 5.x in order to be [compatible](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/version-compatibility.html) with elasticsearch 6.x.