### PR TITLE
Upgrade curator to 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+
+* Upgrade Curator to v5.6.0.
+
 ## 5.0.0
 
 * Upgrade Curator to v5.5.4.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Zappi DevOps <devops@zappistore.com>"
 
 ARG APP_DEPS="python py-setuptools"
 ARG BUILD_DEPS="py-pip"
-ARG CURATOR_VERSION="5.5.4"
+ARG CURATOR_VERSION="5.6.0"
 
 RUN apk --update add ${APP_DEPS} ${BUILD_DEPS} && \
     pip install elasticsearch-curator==${CURATOR_VERSION} && \


### PR DESCRIPTION
As per the title.

See https://github.com/elastic/curator/releases/tag/v5.6.0 for release notes.