### PR TITLE
[SRE-3399] Bump curator version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM alpine:3.10.3
+ARG PYVER=3.11.7
+ARG ALPTAG=3.18
+FROM python:${PYVER}-alpine${ALPTAG}
 
-LABEL maintainer "Zappi DevOps <devops@zappistore.com>"
+LABEL maintainer "Zappi Site Reliability Engineering (SRE) <sre@zappistore.com>"
 
-ARG APP_DEPS="python py-setuptools"
-ARG BUILD_DEPS="py-pip"
-ARG CURATOR_VERSION="5.8.1"
+ARG CURATOR_VERSION="8.0.10"
 
-RUN apk --update add ${APP_DEPS} ${BUILD_DEPS} && \
-    pip install elasticsearch-curator==${CURATOR_VERSION} && \
-    apk del ${BUILD_DEPS} && \
-    rm -rf /var/cache/apk/*
+RUN pip3 install elasticsearch-curator==${CURATOR_VERSION}
 
 USER nobody:nobody
-ENTRYPOINT ["/usr/bin/curator"]
+ENTRYPOINT ["/usr/local/bin/curator"]


### PR DESCRIPTION
### Summary
Bump curator version to resolve client incompatibility. 
![Screenshot 2024-02-12 at 13 05 10](https://github.com/Intellection/docker-elasticsearch-curator/assets/61412032/aebeef21-a203-4046-a291-18518915364e)


Noticed some of the indices were old and should've been cleared by the curator:
<img width="893" alt="Screenshot 2024-02-12 at 13 08 37" src="https://github.com/Intellection/docker-elasticsearch-curator/assets/61412032/49a4c26d-e98e-40e8-bd21-9436d15a3446">
